### PR TITLE
Backport PrintfArg Natural instance to base-4.7

### DIFF
--- a/src/Numeric/Natural.hs
+++ b/src/Numeric/Natural.hs
@@ -43,6 +43,9 @@ import Data.Data
 #ifdef MIN_VERSION_hashable
 import Data.Hashable
 #endif
+#if MIN_VERSION_base(4,7,0) && !(MIN_VERSION_base(4,8,0))
+import Text.Printf (PrintfArg(..), formatInteger)
+#endif
 
 -- | Type representing arbitrary-precision non-negative integers.
 --
@@ -206,3 +209,9 @@ instance Integral Natural where
   {-# INLINE quotRem #-}
   toInteger = runNatural
   {-# INLINE toInteger #-}
+
+#if MIN_VERSION_base(4,7,0) && !(MIN_VERSION_base(4,8,0))
+instance PrintfArg Natural where
+  formatArg     = formatInteger . toInteger
+  parseFormat _ = parseFormat (undefined :: Integer)
+#endif


### PR DESCRIPTION
`base-4.8.0.0` defines a `PrintfArg Natural` instance that `nats` lacks. Unfortunately, it is impossible to backport this instance for `base-4.6` and earlier, since the old `PrintfArg` doesn't expose any of its functions. It does in `base-4.7`, however, so at least that can be backported.