### PR TITLE
Backport Binary instance

### DIFF
--- a/nats.cabal
+++ b/nats.cabal
@@ -47,6 +47,7 @@ library
     exposed-modules: Numeric.Natural
     ghc-options: -Wall
     -- the needlessly relaxed bound here is to due to stack shenanigans
-    build-depends: base >= 2 && < 5
+    build-depends: base   >= 2   && < 5,
+                   binary >= 0.2 && < 0.8
     if flag(hashable)
       build-depends: hashable >= 1.1 && < 1.3


### PR DESCRIPTION
There are currently two `Natural` instances defined in GHC build dependencies for GHC 7.10 and up:

* A `Binary Natural` instance in `binary`
* A `Lift Natural` instance in `template-haskell`

The `Lift` instance is present in `th-orphans` at the moment (due to an oversight on my part), so moving it to `nats` would be tricky. The `Binary` instance, however, can be backported to `nats` with little trouble, which this pull request accomplishes.