### PR TITLE
Backport Lift Natural instance

### DIFF
--- a/nats.cabal
+++ b/nats.cabal
@@ -47,7 +47,8 @@ library
     exposed-modules: Numeric.Natural
     ghc-options: -Wall
     -- the needlessly relaxed bound here is to due to stack shenanigans
-    build-depends: base   >= 2   && < 5,
-                   binary >= 0.2 && < 0.8
+    build-depends: base             >= 2   && < 5,
+                   binary           >= 0.2 && < 0.8,
+                   template-haskell >= 2.2 && < 2.12
     if flag(hashable)
       build-depends: hashable >= 1.1 && < 1.3

--- a/src/Numeric/Natural.hs
+++ b/src/Numeric/Natural.hs
@@ -46,6 +46,7 @@ import Data.Data
 import Data.Hashable
 #endif
 import Data.List (unfoldr)
+import Language.Haskell.TH.Syntax (Lift(..), Exp(LitE), Lit(IntegerL))
 #if MIN_VERSION_base(4,7,0) && !(MIN_VERSION_base(4,8,0))
 import Text.Printf (PrintfArg(..), formatInteger)
 #endif
@@ -255,3 +256,6 @@ instance Binary Natural where
             0 -> liftM fromIntegral (get :: Get NaturalWord)
             _ -> do bytes <- get
                     return $! roll bytes
+
+instance Lift Natural where
+    lift x = return (LitE (IntegerL (fromIntegral x)))

--- a/src/Numeric/Natural.hs
+++ b/src/Numeric/Natural.hs
@@ -10,11 +10,7 @@
 #endif
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-#ifdef MIN_VERSION_hashable
 {-# LANGUAGE Trustworthy #-}
-#else
-{-# LANGUAGE Safe #-}
-#endif
 #endif
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
`template-haskell-2.11.0.0` added a `Lift Natural` instance to coincide with `Numeric.Natural` being moved to `base`. Unfortunately, I made the silly mistake of adding this as an orphan instance to `th-orphans` instead of adding this directly to `nats`. To atone for this mistake, I want to migrate this from `th-orphans` to `nats`.

I've already opened [a pull request](https://github.com/mgsloan/th-orphans/pull/25) on `th-orphans` to remove the orphan `Lift Natural` instance. Once this is accomplished, it can be added safely to `nats`.

One note: I'm not quite sure what upper version bounds to put for `template-haskell`. Realistically, it can't be any greater than `template-haskell-2.10.0.0`, but apparently Stackage plays some games with version bounds (according to your comment [here](https://github.com/ekmett/nats/blob/f0b18711b1af7737d9d4bb96732b347f41b33d76/nats.cabal#L49)), so I made it as wide as possible.