### PR TITLE
Corrent hashable lower bound

### DIFF
--- a/nats.cabal
+++ b/nats.cabal
@@ -88,4 +88,4 @@ library
       build-depends: template-haskell >= 2.2 && < 2.15
 
     if flag(hashable)
-      build-depends: hashable >= 1.1 && < 1.4
+      build-depends: hashable >= 1.1.2.0 && < 1.4


### PR DESCRIPTION
We need `Hashable Integer` which is since 1.1.2.0

---

I made revisions on Hackage, so no further action is required.